### PR TITLE
Changed shortcut to alternative for consistency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Check `:help ctrlp-commands` and `:help ctrlp-extensions` for other commands.
 * Press `<c-d>` to switch to filename only search instead of full path.
 * Press `<c-r>` to switch to regexp mode.
 * Use `<c-j>`, `<c-k>` or the arrow keys to navigate the result list.
-* Use `<c-t>` or `<c-v>`, `<c-x>` to open the selected entry in a new tab or in a new split.
+* Use `<c-t>` or `<c-s>`, `<c-v>` to open the selected entry in a new tab or in a new split.
 * Use `<c-n>`, `<c-p>` to select the next/previous string in the prompt's history.
 * Use `<c-y>` to create a new file and its parent directories.
 * Use `<c-z>` to mark/unmark multiple files and `<c-o>` to open them.


### PR DESCRIPTION
I changed the shortcut for open file in (horizontal) split to `<c-s>`. I think it is much easier to memorize: `s` for the default (horizontal) `:split` command.

Also I changed the order of the shortcuts because `<c-s>` is the "default" horizontal split vs. `:vs[plit]`, `:vert[ical] sp[lit]`

The consistency to the commands in the Vim quickfix list is not fully perfect, though:

 - `<c-e>` -> `e` -> edit
 - `<c-t>` -> `t` -> new tab
 - `<c-v>` -> `v` -> vertical split
 - `<c-s>` -> `h` -> (horizontal) split, like `:split`